### PR TITLE
#532 update sidebar

### DIFF
--- a/resources/icons/equipment.svg
+++ b/resources/icons/equipment.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+    <g fill="none"
+       stroke="currentColor"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       stroke-width="2">
+        <path d="M12 11v4m2-2h-4m6-7V4a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v2m10 0v14M6 6v14"/>
+        <rect width="20" height="14" x="2" y="6" rx="2"/></g>
+</svg>

--- a/resources/views/livewire/components/sidebar.blade.php
+++ b/resources/views/livewire/components/sidebar.blade.php
@@ -175,6 +175,17 @@
                         </a>
                     </li>
                 @endif
+
+                    @can('viewAny', Equipment::class)
+                        <li>
+                            <a href="{{ route('equipment.index', [legalEntity()]) }}"
+                               class="flex items-center p-2 text-base font-medium text-gray-900 rounded-lg dark:text-white hover:bg-gray-100 dark:hover:bg-gray-700 group"
+                            >
+                                @icon('equipment', 'w-6 h-6 text-gray-500 transition duration-75 dark:text-gray-400 group-hover:text-gray-900 dark:group-hover:text-white')
+                                <span class="ml-3">{{ __('equipment.equipment') }}</span>
+                            </a>
+                        </li>
+                    @endcan
             @endif
         </ul>
     </div>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added an Equipment item to the sidebar with a new icon. It’s shown only to users allowed to view equipment and links to the Equipment list.

- **New Features**
  - Added equipment.svg icon.
  - Added “Equipment” sidebar link gated by viewAny on Equipment, routing to equipment.index for the current legal entity.

<sup>Written for commit fa417808cfa028be91a51f0a664308848f0d7350. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

