### PR TITLE
#600 update frontend modals

### DIFF
--- a/resources/lang/uk/patients.php
+++ b/resources/lang/uk/patients.php
@@ -303,6 +303,15 @@ return [
     'update_method_alias' => 'Оновлення назви методу автентифікації',
     'load_person_documents' => 'Завантажте будь ласка документи пацієнта',
     'new_alias_method' => 'Введіть будь ласка нову назву методу автентифікації',
+    'add_authentication_method' => 'Додати метод автентифікації',
+    'authentication_from_SMS' => 'Автентифікація через СМС',
+    'adding_authentication_method_SMS' => 'Додавання методу автентифікації - через СМС',
+    'authentication_method_name' => 'Назва методу автентифікації',
+    'authentication_through_documents' => 'Автентифікація через документи',
+    'file_not_selected' => 'Файл не обрано',
+    'select_file' => 'Вибрати файл',
+    'the_size_uploaded_file' => 'Розмір завантажуваного файлу не більше 10МБ у форматі jpeg',
+    'send_files' => 'Відправити файли',
 
     'errors' => [
         'authMethod' => [

--- a/resources/views/livewire/person/parts/modals/authentication-from-documents.blade.php
+++ b/resources/views/livewire/person/parts/modals/authentication-from-documents.blade.php
@@ -1,0 +1,89 @@
+<div wire:key="auth-step-add-sms-full">
+    <legend class="legend">
+        {{ __('patients.adding_authentication_method_SMS') }}
+    </legend>
+
+    <div class="space-y-8">
+        <div class="space-y-6">
+            <div class="form-row-3">
+                <div class="form-group group">
+                    <input type="tel"
+                           placeholder=" "
+                           class="peer input !py-2"
+                           wire:model="form.phoneNumber"
+                           id="add_sms_phone"
+                           x-mask="+380999999999"
+                    />
+                    <label class="label" for="add_sms_phone">{{ __('+380') }}</label>
+                </div>
+            </div>
+
+            <div class="form-row-3">
+                <div class="form-group group">
+                    <input type="text"
+                           placeholder=" "
+                           class="peer input !py-2"
+                           wire:model="form.methodName"
+                           id="add_sms_name"
+                    />
+                    <label class="label" for="add_sms_name">{{ __('patients.authentication_method_name') }}}</label>
+                </div>
+            </div>
+        </div>
+
+        <div class="pt-4">
+            <h3 class="text-xl font-bold mb-6 text-gray-900 dark:text-white">
+                {{ __('patients.code_SMS') }}}
+            </h3>
+
+            <div class="form-row-4 flex items-end gap-4" style="display: flex; align-items: flex-end;">
+                <div class="form-group group !mb-0" style="flex: 0 1 300px;">
+                    <input type="text"
+                           placeholder=" "
+                           class="peer input !py-2"
+                           wire:model="smsCode"
+                           id="smsCode"
+                    />
+                    <label class="label" for="smsCode">{{ __('patients.confirmation_code') }}}</label>
+                </div>
+
+                <div x-data="{
+                    timer: 60,
+                    init() {
+                        let interval = setInterval(() => {
+                            if (this.timer > 0) this.timer--;
+                            else clearInterval(interval);
+                        }, 1000);
+                    }
+                }" class="shrink-0">
+                    <button type="button"
+                            :disabled="timer > 0"
+                            class="bg-white border border-gray-200 rounded-lg px-4 py-2.5 flex items-center gap-2 text-sm transition-colors disabled:opacity-70 whitespace-nowrap"
+                            :class="timer > 0 ? 'cursor-not-allowed' : 'hover:bg-gray-50'"
+                            wire:click="resendSms"
+                    >
+                        @icon('mail', 'w-4 h-4 text-gray-600')
+                        <span class="text-gray-700">
+                            <span x-show="timer > 0">{{ __('Відправити ще раз (через') }} <span x-text="timer"></span> {{ __('с)') }}</span>
+                            <span x-show="timer === 0">{{ __('patients.send_again') }}</span>
+                        </span>
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="mt-12 flex gap-3">
+        <button type="button" wire:click="setStep(0)" class="button-minor">
+            {{ __('forms.back') }}
+        </button>
+
+        <button type="button" wire:click="setStep(0)" class="button-outline-primary">
+            {{ __('patients.to_authentication_methods') }}
+        </button>
+
+        <button type="button" wire:click="submitSmsMethod" class="button-primary">
+            {{ __('patients.confirm') }}
+        </button>
+    </div>
+</div>

--- a/resources/views/livewire/person/parts/modals/authentication-from-sms-1.blade.php
+++ b/resources/views/livewire/person/parts/modals/authentication-from-sms-1.blade.php
@@ -1,0 +1,42 @@
+<div wire:key="auth-step-add-sms">
+    <legend class="legend">
+        {{ __('patients.adding_authentication_method_SMS') }}
+    </legend>
+
+    <div class="space-y-10">
+        <div class="form-row-3">
+            <div class="form-group group">
+                <input type="tel"
+                       placeholder=" "
+                       class="peer input !py-2"
+                       wire:model="form.phoneNumber"
+                       id="add_sms_phone"
+                       x-mask="+380999999999"
+                />
+                <label class="label" for="add_sms_phone">{{ __('+380') }}</label>
+            </div>
+        </div>
+
+        <div class="form-row-3">
+            <div class="form-group group">
+                <input type="text"
+                       placeholder=" "
+                       class="peer input !py-2"
+                       wire:model="form.methodName"
+                       id="add_sms_name"
+                />
+                <label class="label" for="add_sms_name">{{ __('Назва методу автентифікації') }}</label>
+            </div>
+        </div>
+    </div>
+
+    <div class="mt-12 flex gap-4">
+        <button type="button" wire:click="setStep(0)" class="button-minor">
+            {{ __('forms.back') }}
+        </button>
+
+        <button type="button" wire:click="submitSmsMethod" class="button-primary">
+            {{ __('patients.confirm') }}
+        </button>
+    </div>
+</div>

--- a/resources/views/livewire/person/parts/modals/authentication-from-sms-2.blade.php
+++ b/resources/views/livewire/person/parts/modals/authentication-from-sms-2.blade.php
@@ -1,0 +1,89 @@
+<div wire:key="auth-step-add-sms-full">
+    <legend class="legend">
+        {{ __('patients.adding_authentication_method_SMS') }}
+    </legend>
+
+    <div class="space-y-8">
+        <div class="space-y-6">
+            <div class="form-row-3">
+                <div class="form-group group">
+                    <input type="tel"
+                           placeholder=" "
+                           class="peer input !py-2"
+                           wire:model="form.phoneNumber"
+                           id="add_sms_phone"
+                           x-mask="+380999999999"
+                    />
+                    <label class="label" for="add_sms_phone">{{ __('+380') }}</label>
+                </div>
+            </div>
+
+            <div class="form-row-3">
+                <div class="form-group group">
+                    <input type="text"
+                           placeholder=" "
+                           class="peer input !py-2"
+                           wire:model="form.methodName"
+                           id="add_sms_name"
+                    />
+                    <label class="label" for="add_sms_name">{{ __('patients.authentication_method_name') }}}</label>
+                </div>
+            </div>
+        </div>
+
+        <div class="pt-4">
+            <h3 class="text-xl font-bold mb-6 text-gray-900 dark:text-white">
+                {{ __('patients.code_SMS') }}}
+            </h3>
+
+            <div class="form-row-4 flex items-end gap-4" style="display: flex; align-items: flex-end;">
+                <div class="form-group group !mb-0" style="flex: 0 1 300px;">
+                    <input type="text"
+                           placeholder=" "
+                           class="peer input !py-2"
+                           wire:model="smsCode"
+                           id="smsCode"
+                    />
+                    <label class="label" for="smsCode">{{ __('patients.confirmation_code') }}}</label>
+                </div>
+
+                <div x-data="{
+                    timer: 60,
+                    init() {
+                        let interval = setInterval(() => {
+                            if (this.timer > 0) this.timer--;
+                            else clearInterval(interval);
+                        }, 1000);
+                    }
+                }" class="shrink-0">
+                    <button type="button"
+                            :disabled="timer > 0"
+                            class="bg-white border border-gray-200 rounded-lg px-4 py-2.5 flex items-center gap-2 text-sm transition-colors disabled:opacity-70 whitespace-nowrap"
+                            :class="timer > 0 ? 'cursor-not-allowed' : 'hover:bg-gray-50'"
+                            wire:click="resendSms"
+                    >
+                        @icon('mail', 'w-4 h-4 text-gray-600')
+                        <span class="text-gray-700">
+                            <span x-show="timer > 0">{{ __('Відправити ще раз (через') }} <span x-text="timer"></span> {{ __('с)') }}</span>
+                            <span x-show="timer === 0">{{ __('patients.send_again') }}</span>
+                        </span>
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="mt-12 flex gap-3">
+        <button type="button" wire:click="setStep(0)" class="button-minor">
+            {{ __('forms.back') }}
+        </button>
+
+        <button type="button" wire:click="setStep(0)" class="button-outline-primary">
+            {{ __('patients.to_authentication_methods') }}
+        </button>
+
+        <button type="button" wire:click="submitSmsMethod" class="button-primary">
+            {{ __('patients.confirm') }}
+        </button>
+    </div>
+</div>

--- a/resources/views/livewire/person/parts/modals/choose-auth-method.blade.php
+++ b/resources/views/livewire/person/parts/modals/choose-auth-method.blade.php
@@ -3,290 +3,328 @@
 <div x-data="{
         showAuthMethodModal: $wire.entangle('showAuthMethodModal'),
         authenticationMethods: $wire.entangle('authenticationMethods'),
-        selectedMethod: $wire.entangle('form.authorizeWith')
+        selectedMethod: $wire.entangle('form.authorizeWith'),
+        localStep: 0
     }"
+     x-init="$watch('showAuthMethodModal', value => { if (!value) localStep = 0 })"
 >
     <template x-teleport="body">
         <div x-show="showAuthMethodModal"
              style="display: none"
-             @keydown.escape.prevent.stop="showAuthMethodModal = false"
+             @keydown.escape.prevent.stop="showAuthMethodModal = false; localStep = 0"
              role="dialog"
              aria-modal="true"
              class="modal"
         >
             <div x-transition.opacity class="fixed inset-0 bg-black/30"></div>
-            <div x-transition @click="showAuthMethodModal = false" class="modal-wrapper">
+            <div x-transition @click="showAuthMethodModal = false; localStep = 0" class="modal-wrapper">
                 <div @click.stop
                      x-trap.noscroll.inert="showAuthMethodModal"
                      class="modal-content w-full max-w-4xl mx-auto"
                 >
-                    @if($authStep === 0)
-                        <div wire:key="auth-step-0">
-                            <legend class="legend mb-8">{{ __('patients.authentication_methods') }}</legend>
+                    <!-- Крок 0: Головне меню -->
+                    <div x-show="localStep === 0" wire:key="auth-step-0">
+                        <div class="flex items-center justify-between mb-8">
+                            <legend class="legend !mb-0">{{ __('patients.authentication_methods') }}</legend>
 
-                            <template x-if="!authenticationMethods || authenticationMethods.length === 0">
-                                <div class="bg-red-100 rounded-lg mb-8">
-                                    <div class="p-4">
-                                        <div class="flex items-center gap-2 mb-2">
-                                            @icon('alert-circle', 'w-5 h-5 text-red-700')
-                                            <p class="font-semibold text-red-700">{{ __('forms.patient_has_no_auth_methods') }}</p>
-                                        </div>
+                            <div x-data="{ openAdd: false }" class="relative">
+                                <button @click="openAdd = !openAdd"
+                                        type="button"
+                                        class="item-add"
+                                >
+                                    <span>{{ __('patients.add_authentication_method') }}</span>
+                                </button>
+
+                                <div x-show="openAdd"
+                                     @click.away="openAdd = false"
+                                     x-transition:enter="transition ease-out duration-100"
+                                     x-transition:enter-start="opacity-0 scale-95"
+                                     x-transition:enter-end="opacity-100 scale-100"
+                                     style="display: none"
+                                     class="absolute right-0 mt-2 w-72 bg-white rounded-lg shadow-xl z-50 p-1 border border-gray-100"
+                                >
+                                    <button @click="localStep = 1; openAdd = false"
+                                            class="w-full text-left px-4 py-2 text-sm hover:bg-gray-50 rounded text-gray-700 transition-colors">
+                                        Автентифікація через СМС
+                                    </button>
+
+                                    <button @click="localStep = 5; openAdd = false"
+                                            class="w-full text-left px-4 py-2 text-sm hover:bg-gray-50 rounded text-gray-700 transition-colors">
+                                        Автентифікація через документи
+                                    </button>
+
+                                    <button @click="localStep = 4; openAdd = false"
+                                            class="w-full text-left px-4 py-2 text-sm hover:bg-gray-50 rounded text-gray-700 transition-colors">
+                                        Автентифікація через третю особу
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+
+                        <template x-if="!authenticationMethods || authenticationMethods.length === 0">
+                            <div class="bg-red-100 rounded-lg mb-8">
+                                <div class="p-4">
+                                    <div class="flex items-center gap-2 mb-2">
+                                        @icon('alert-circle', 'w-5 h-5 text-red-700')
+                                        <p class="font-semibold text-red-700">{{ __('forms.patient_has_no_auth_methods') }}</p>
                                     </div>
                                 </div>
-                            </template>
+                            </div>
+                        </template>
 
-                            <template x-if="authenticationMethods && authenticationMethods.length > 0">
-                                <div class="space-y-4">
-                                    <template x-for="method in authenticationMethods" :key="method.uuid">
-                                        <div class="fieldset border dark:border-white p-3 rounded space-y-3">
-                                            <div class="flex items-start justify-between">
-                                                <div class="shrink"
-                                                     x-data="{
-                                                         labels: @js(AuthenticationMethod::options()),
-                                                         prefix: '{{ __('forms.authentication') }}'
-                                                     }"
-                                                >
-                                                    <h3 class="text-gray-900 dark:text-white font-bold"
-                                                        x-text="`${prefix} ${labels[method.type] ?? method.type}`"
-                                                    ></h3>
-
-                                                    <p class="default-p"
-                                                       x-text="'{{ __('patients.method_name') }}: ' + (method.alias || '—')"
-                                                    ></p>
-                                                </div>
-
-                                                <div class="flex items-center gap-4">
-                                                    <div x-data="{ open: false }" class="relative">
-                                                        <button @click="open = !open" type="button"
-                                                                class="text-blue-600 hover:underline text-sm whitespace-nowrap"
-                                                        >
-                                                            {{ __('patients.change') }}
-                                                        </button>
-
-                                                        <div x-show="open"
-                                                             @click.away="open = false"
-                                                             style="display: none"
-                                                             class="absolute right-0 mt-2 w-64 bg-white rounded-lg shadow-xl z-50 p-2 border border-gray-100"
-                                                        >
-                                                            <template x-if="method.type === '{{ AuthenticationMethod::OTP->value }}'">
-                                                                <button @click="open = false"
-                                                                        wire:click.prevent="selectAuthMethod(method.uuid, method.type, 1)"
-                                                                        class="w-full text-left px-3 py-2 text-sm hover:bg-gray-100 rounded text-gray-700"
-                                                                >
-                                                                    {{ __('patients.change_phone_number') }}
-                                                                </button>
-                                                            </template>
-
-                                                            <template x-if="method.type === '{{ AuthenticationMethod::OFFLINE->value }}'">
-                                                                <button wire:click.prevent="selectAuthMethod(method.uuid, method.type, 1)"
-                                                                        @click="open = false"
-                                                                        class="w-full text-left px-3 py-2 text-sm hover:bg-gray-100 rounded text-gray-700"
-                                                                >
-                                                                    {{ __('patients.change_method_to_sms') }}
-                                                                </button>
-                                                            </template>
-
-                                                            <button @click="open = false"
-                                                                    wire:click.prevent="selectAuthMethod(method.uuid, method.type, 7)"
-                                                                    class="w-full text-left px-3 py-2 text-sm hover:bg-gray-100 rounded text-gray-700"
-                                                            >
-                                                                {{ __('patients.change_method_alias') }}
-                                                            </button>
-
-                                                            <button wire:click.prevent="selectAuthMethod(method.uuid, method.type, 3)"
-                                                                    @click="open = false"
-                                                                    class="w-full text-left px-3 py-2 text-sm hover:bg-gray-100 rounded text-gray-700"
-                                                            >
-                                                                {{ __('patients.deactivate_method') }}
-                                                            </button>
-                                                        </div>
-                                                    </div>
-
-                                                    <button wire:click="update"
-                                                            class="button-primary whitespace-nowrap"
-                                                            @click="selectedMethod = method.id || method.uuid; showAuthMethodModal = false"
-                                                    >
-                                                        {{ __('forms.select') }}
-                                                    </button>
-                                                </div>
+                        <template x-if="authenticationMethods && authenticationMethods.length > 0">
+                            <div class="space-y-4">
+                                <template x-for="method in authenticationMethods" :key="method.uuid">
+                                    <div class="fieldset border dark:border-white p-3 rounded space-y-3">
+                                        <div class="flex items-start justify-between">
+                                            <div class="shrink"
+                                                 x-data="{
+                                                     labels: @js(AuthenticationMethod::options()),
+                                                     prefix: '{{ __('forms.authentication') }}'
+                                                 }"
+                                            >
+                                                <h3 class="text-gray-900 dark:text-white font-bold"
+                                                    x-text="`${prefix} ${labels[method.type] ?? method.type}`"
+                                                ></h3>
                                             </div>
 
-                                            <div class="space-y-2">
-                                                <template x-if="method.type === '{{ AuthenticationMethod::OTP->value }}'">
-                                                    <div class="space-y-4">
-                                                        <label for="phoneNumber" class="label-modal">
-                                                            {{ __('forms.phone_number') }}
-                                                        </label>
-                                                        <div class="form-row-3">
-                                                            <input type="tel"
+                                            <div class="flex items-center gap-4">
+                                                <div x-data="{ open: false }" class="relative">
+                                                    <button @click="open = !open" type="button"
+                                                            class="text-blue-600 hover:underline text-sm whitespace-nowrap"
+                                                    >
+                                                        {{ __('Змінити') }}
+                                                    </button>
+
+                                                    <div x-show="open"
+                                                         @click.away="open = false"
+                                                         style="display: none"
+                                                         class="absolute right-0 mt-2 w-64 bg-white rounded-lg shadow-xl z-50 p-2 border border-gray-100"
+                                                    >
+                                                        <template x-if="method.type === '{{ AuthenticationMethod::OTP->value }}'">
+                                                            <button @click="localStep = 1; open = false"
+                                                                    class="w-full text-left px-3 py-2 text-sm hover:bg-gray-100 rounded text-gray-700"
+                                                            >
+                                                                Змінити номер телефона
+                                                            </button>
+                                                        </template>
+
+                                                        <template x-if="method.type === '{{ AuthenticationMethod::OFFLINE->value }}'">
+                                                            <button @click="localStep = 1; open = false"
+                                                                    class="w-full text-left px-3 py-2 text-sm hover:bg-gray-100 rounded text-gray-700"
+                                                            >
+                                                                Замінити метод на СМС
+                                                            </button>
+                                                        </template>
+
+                                                        <button @click="localStep = 5; open = false"
+                                                                class="w-full text-left px-3 py-2 text-sm hover:bg-gray-100 rounded text-gray-700"
+                                                        >
+                                                            Деактивувати метод
+                                                        </button>
+                                                    </div>
+                                                </div>
+
+                                                <button wire:click="update"
+                                                        class="button-primary whitespace-nowrap"
+                                                        @click="selectedMethod = method.id || method.uuid; showAuthMethodModal = false; localStep = 0"
+                                                >
+                                                    {{ __('forms.select') }}
+                                                </button>
+                                            </div>
+                                        </div>
+
+                                        <div class="space-y-2">
+                                            <template x-if="method.type === '{{ AuthenticationMethod::OTP->value }}'">
+                                                <div class="space-y-4">
+                                                    <label for="phoneNumber" class="label-modal">
+                                                        {{ __('forms.phone_number') }}
+                                                    </label>
+                                                    <div class="form-row-3">
+                                                        <input type="tel"
+                                                               class="input-modal"
+                                                               :value="method.phoneNumber"
+                                                               id="phoneNumber"
+                                                               readonly
+                                                        >
+                                                    </div>
+                                                </div>
+                                            </template>
+
+                                            <template x-if="method.type === '{{ AuthenticationMethod::THIRD_PERSON->value }}'">
+                                                <div class="space-y-4">
+                                                    <div class="form-row-2">
+                                                        <div class="form-group">
+                                                            <label for="alias" class="label-modal">
+                                                                {{ __('patients.alias') }}
+                                                            </label>
+                                                            <input type="text"
+                                                                   :value="method.alias"
                                                                    class="input-modal"
-                                                                   :value="method.phoneNumber"
-                                                                   id="phoneNumber"
+                                                                   name="alias"
+                                                                   readonly
+                                                            >
+                                                        </div>
+
+                                                        <div class="form-group"
+                                                             x-data="{ endedAt: method.ehealthEndedAt || method.endedAt }"
+                                                        >
+                                                            @icon('calendar-month', 'w-5 h-5 svg-input absolute left-1 !top-2/3 transform -translate-y-1/2 pointer-events-none')
+
+                                                            <label for="endedAt" class="label-modal">
+                                                                {{ __('patients.ended_at') }}
+                                                                <span class="text-red-600"></span>
+                                                            </label>
+                                                            <input x-model="endedAt"
+                                                                   x-init="$nextTick(() => { if (endedAt) $el.value = endedAt })"
+                                                                   datepicker-max-date="{{ now()->format('d.m.Y') }}"
+                                                                   datepicker-format="dd.mm.yyyy"
+                                                                   type="text"
+                                                                   name="endedAt"
+                                                                   id="endedAt"
+                                                                   class="input-modal datepicker-input"
+                                                                   autocomplete="off"
                                                                    readonly
                                                             >
                                                         </div>
                                                     </div>
-                                                </template>
 
-                                                <template x-if="method.type === '{{ AuthenticationMethod::THIRD_PERSON->value }}'">
-                                                    <div class="space-y-4">
-                                                        <div class="form-row-2">
-                                                            <div class="form-group">
-                                                                <label for="alias" class="label-modal">
-                                                                    {{ __('patients.alias') }}
-                                                                </label>
-                                                                <input type="text"
-                                                                       :value="method.alias"
-                                                                       class="input-modal"
-                                                                       name="alias"
-                                                                       readonly
-                                                                >
-                                                            </div>
-
-                                                            <div class="form-group"
-                                                                 x-data="{ endedAt: method.ehealthEndedAt || method.endedAt }"
+                                                    <div class="form-row-2">
+                                                        <div class="form-group">
+                                                            <label for="confidantPersonFullName"
+                                                                   class="label-modal"
                                                             >
-                                                                @icon('calendar-month', 'w-5 h-5 svg-input absolute left-1 !top-2/3 transform -translate-y-1/2 pointer-events-none')
-
-                                                                <label for="endedAt" class="label-modal">
-                                                                    {{ __('patients.ended_at') }}
-                                                                    <span class="text-red-600"></span>
-                                                                </label>
-                                                                <input x-model="endedAt"
-                                                                       x-init="$nextTick(() => { if (endedAt) $el.value = endedAt })"
-                                                                       datepicker-max-date="{{ now()->format('d.m.Y') }}"
-                                                                       datepicker-format="dd.mm.yyyy"
-                                                                       type="text"
-                                                                       name="endedAt"
-                                                                       id="endedAt"
-                                                                       class="input-modal datepicker-input"
-                                                                       autocomplete="off"
-                                                                       readonly
-                                                                >
-                                                            </div>
+                                                                {{ __('patients.confidant_full_name') }}
+                                                            </label>
+                                                            <input type="text"
+                                                                   :value="method.confidantPerson.name"
+                                                                   class="input-modal"
+                                                                   id="confidantPersonFullName"
+                                                                   name="confidantPersonFullName"
+                                                                   readonly
+                                                            >
                                                         </div>
 
-                                                        <div class="form-row-2">
-                                                            <div class="form-group">
-                                                                <label for="confidantPersonFullName"
-                                                                       class="label-modal"
-                                                                >
-                                                                    {{ __('patients.confidant_full_name') }}
-                                                                </label>
-                                                                <input type="text"
-                                                                       :value="method.confidantPerson.name"
-                                                                       class="input-modal"
-                                                                       id="confidantPersonFullName"
-                                                                       name="confidantPersonFullName"
-                                                                       readonly
-                                                                >
-                                                            </div>
-
-                                                            <div class="form-group">
-                                                                <label for="taxId" class="label-modal">
-                                                                    {{ __('forms.rnokpp') }}
-                                                                    <span class="text-red-600"></span>
-                                                                </label>
-                                                                <input :value="method.confidantPerson.taxId"
-                                                                       type="text"
-                                                                       name="taxId"
-                                                                       id="taxId"
-                                                                       class="input-modal"
-                                                                       autocomplete="off"
-                                                                       readonly
-                                                                >
-                                                            </div>
-                                                        </div>
-
-                                                        <div class="form-row-2">
-                                                            <div class="form-group">
-                                                                <label for="unzr" class="label-modal">
-                                                                    {{ __('patients.unzr') }}
-                                                                </label>
-                                                                <input type="text"
-                                                                       :value="method.confidantPerson.unzr"
-                                                                       class="input-modal"
-                                                                       name="unzr"
-                                                                       readonly
-                                                                >
-                                                            </div>
-                                                        </div>
-
-                                                        <template :key="method.uuid"
-                                                                  x-for="document in method.confidantPerson.documentsPerson"
-                                                        >
-                                                            <div class="form-row-2">
-                                                                <div class="form-group"
-                                                                     x-data="{
-                                                                         documentLabels: @js(__('patients.documents')),
-                                                                         getDocumentLabel(type) {
-                                                                             return this.documentLabels[type?.toLowerCase()] ?? type
-                                                                         }
-                                                                     }"
-                                                                >
-                                                                    <label for="documentType" class="label-modal">
-                                                                        {{ __('forms.document_type') }}
-                                                                        <span class="text-red-600"></span>
-                                                                    </label>
-                                                                    <input :value="getDocumentLabel(document.type)"
-                                                                           type="text"
-                                                                           name="documentType"
-                                                                           id="documentType"
-                                                                           class="input-modal"
-                                                                           autocomplete="off"
-                                                                           readonly
-                                                                    >
-                                                                </div>
-
-                                                                <div class="form-group">
-                                                                    <label for="documentNumber" class="label-modal">
-                                                                        {{ __('forms.document_number') }}
-                                                                    </label>
-                                                                    <input type="text"
-                                                                           :value="document.number"
-                                                                           class="input-modal"
-                                                                           name="documentNumber"
-                                                                           readonly
-                                                                    >
-                                                                </div>
-                                                            </div>
-                                                        </template>
-
-                                                        <div class="form-row-2">
-                                                            <div class="form-group">
-                                                                <label for="phoneNumber" class="label-modal">
-                                                                    {{ __('forms.phone_number') }}
-                                                                    <span class="text-red-600"></span>
-                                                                </label>
-                                                                <input :value="method.confidantPerson.phones.number"
-                                                                       type="tel"
-                                                                       name="phoneNumber"
-                                                                       id="phoneNumber"
-                                                                       class="input-modal"
-                                                                       autocomplete="off"
-                                                                       readonly
-                                                                >
-                                                            </div>
+                                                        <div class="form-group">
+                                                            <label for="taxId" class="label-modal">
+                                                                {{ __('forms.rnokpp') }}
+                                                                <span class="text-red-600"></span>
+                                                            </label>
+                                                            <input :value="method.confidantPerson.taxId"
+                                                                   type="text"
+                                                                   name="taxId"
+                                                                   id="taxId"
+                                                                   class="input-modal"
+                                                                   autocomplete="off"
+                                                                   readonly
+                                                            >
                                                         </div>
                                                     </div>
-                                                </template>
-                                            </div>
-                                        </div>
-                                    </template>
-                                </div>
-                            </template>
 
-                            <div class="flex justify-between items-center mt-8">
-                                <button type="button" @click="showAuthMethodModal = false" class="button-minor">
-                                    {{ __('forms.cancel') }}
-                                </button>
+                                                    <div class="form-row-2">
+                                                        <div class="form-group">
+                                                            <label for="unzr" class="label-modal">
+                                                                {{ __('patients.unzr') }}
+                                                            </label>
+                                                            <input type="text"
+                                                                   :value="method.confidantPerson.unzr"
+                                                                   class="input-modal"
+                                                                   name="unzr"
+                                                                   readonly
+                                                            >
+                                                        </div>
+                                                    </div>
+
+                                                    <template :key="method.uuid"
+                                                              x-for="document in method.confidantPerson.documentsPerson"
+                                                    >
+                                                        <div class="form-row-2">
+                                                            <div class="form-group"
+                                                                 x-data="{
+                                                                     documentLabels: @js(__('patients.documents')),
+                                                                     getDocumentLabel(type) {
+                                                                         return this.documentLabels[type?.toLowerCase()] ?? type
+                                                                     }
+                                                                 }"
+                                                            >
+                                                                <label for="documentType" class="label-modal">
+                                                                    {{ __('forms.document_type') }}
+                                                                    <span class="text-red-600"></span>
+                                                                </label>
+                                                                <input :value="getDocumentLabel(document.type)"
+                                                                       type="text"
+                                                                       name="documentType"
+                                                                       id="documentType"
+                                                                       class="input-modal"
+                                                                       autocomplete="off"
+                                                                       readonly
+                                                                >
+                                                            </div>
+
+                                                            <div class="form-group">
+                                                                <label for="documentNumber" class="label-modal">
+                                                                    {{ __('forms.document_number') }}
+                                                                </label>
+                                                                <input type="text"
+                                                                       :value="document.number"
+                                                                       class="input-modal"
+                                                                       name="documentNumber"
+                                                                       readonly
+                                                                >
+                                                            </div>
+                                                        </div>
+                                                    </template>
+
+                                                    <div class="form-row-2">
+                                                        <div class="form-group">
+                                                            <label for="phoneNumber" class="label-modal">
+                                                                {{ __('forms.phone_number') }}
+                                                                <span class="text-red-600"></span>
+                                                            </label>
+                                                            <input :value="method.confidantPerson.phones.number"
+                                                                   type="tel"
+                                                                   name="phoneNumber"
+                                                                   id="phoneNumber"
+                                                                   class="input-modal"
+                                                                   autocomplete="off"
+                                                                   readonly
+                                                            >
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </template>
+                                        </div>
+                                    </div>
+                                </template>
                             </div>
+                        </template>
+
+                        <div class="flex justify-between items-center mt-8">
+                            <button type="button" @click="showAuthMethodModal = false; localStep = 0" class="button-minor">
+                                {{ __('forms.cancel') }}
+                            </button>
                         </div>
-                    @else
-                        <div wire:key="auth-step-{{ $authStep }}">
-                            @include('livewire.person.parts.modals.choose-auth-method-' . $authStep)
-                        </div>
-                    @endif
+                    </div>
+
+                    <div x-show="localStep === 1" style="display: none">
+                        @include('livewire.person.parts.modals.authentication-from-sms-1')
+                    </div>
+
+                    <div x-show="localStep === 2" style="display: none">
+                        @include('livewire.person.parts.modals.authentication-from-sms-2')
+                    </div>
+
+                    <div x-show="localStep === 3" style="display: none">
+                        @include('livewire.person.parts.modals.choose-auth-method-3')
+                    </div>
+
+                    <div x-show="localStep === 4" style="display: none">
+                        @include('livewire.person.parts.modals.choose-auth-method-4')
+                    </div>
+
+                    <div x-show="localStep === 5" style="display: none">
+                        @include('livewire.person.parts.modals.authentication-from-documents')
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Modernizes the person authentication modal with a compact, step-based UI and adds dedicated flows for SMS and documents.
> 
> - Refactors `choose-auth-method.blade.php` to an Alpine `localStep`-driven modal; resets state on close and adds an “Add authentication method” dropdown (SMS, documents, third person)
> - Introduces `authentication-from-sms-1` (phone + method name) and `authentication-from-sms-2` (SMS code + resend timer) partials, plus `authentication-from-documents`
> - Updates method action menu for existing entries (change phone, replace offline with SMS, deactivate) and retains detailed views for OTP/third-person methods
> - Expands `patients.php` with new Ukrainian strings for the new flows and file upload prompts
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd68f56c258c1a06cec04ac1f34cf68735dd32d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reworked the person authentication modal into a simple step-based flow and added new SMS and documents authentication modals. This makes adding and managing methods clearer and faster.

- **New Features**
  - Step-based modal navigation with local state; resets when closed.
  - “Add authentication method” menu with options: SMS, documents, third person.
  - SMS flow: phone input, method name, code entry, and resend timer.
  - Improved actions on existing methods: change phone, replace with SMS, deactivate.
  - Added Ukrainian translations for SMS/documents flows and file upload prompts.

<sup>Written for commit dd68f56c258c1a06cec04ac1f34cf68735dd32d1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

